### PR TITLE
separate Card into two different things: Permanent, and Card

### DIFF
--- a/game/action.go
+++ b/game/action.go
@@ -7,7 +7,8 @@ import (
 type Action struct {
 	Type       ActionType
 	Card       *Card
-	Target     *Card
+	With       *Permanent
+	Target     *Permanent
 	WithKicker bool
 }
 
@@ -23,15 +24,15 @@ const (
 	ChooseTargetAndMana
 )
 
-func (a *Action) pronoun() string {
-	if a.Target.Owner == a.Card.Owner {
+func (a *Action) targetPronoun(p *Player) string {
+	if a.Target.Owner == p {
 		return "your"
 	}
 	return "their"
 }
 
 // For debugging and logging. Don't use this in the critical path.
-func (a *Action) String() string {
+func (a *Action) ShowTo(p *Player) string {
 	switch a.Type {
 	case Pass:
 		return "pass"
@@ -40,25 +41,27 @@ func (a *Action) String() string {
 	case Play:
 		if a.WithKicker {
 			if a.Target == nil {
-				return fmt.Sprintf("%v: %v with kicker", a.Card.Kicker.Cost, a.Card.String())
+				return fmt.Sprintf("%d: %s with kicker", a.Card.Kicker.Cost, a.Card)
 			}
-			return fmt.Sprintf("%v: %v on %v %v with kicker", a.Card.Kicker.Cost, a.Card.String(), a.pronoun(), a.Target.String())
+			return fmt.Sprintf("%d: %s on %s %s with kicker",
+				a.Card.Kicker.Cost, a.Card, a.targetPronoun(p), a.Target)
 		}
 		if a.Card.IsLand {
-			return fmt.Sprintf("%v", a.Card.String())
+			return fmt.Sprintf("%s", a.Card)
 		}
 		if a.Target == nil {
-			return fmt.Sprintf("%v: %v", a.Card.ManaCost, a.Card.String())
+			return fmt.Sprintf("%d: %s", a.Card.ManaCost, a.Card)
 		}
-		return fmt.Sprintf("%v: %v on %v %v", a.Card.ManaCost, a.Card.String(), a.pronoun(), a.Target.String())
+		return fmt.Sprintf("%d: %s on %s %s",
+			a.Card.ManaCost, a.Card, a.targetPronoun(p), a.Target)
 	case DeclareAttack:
 		return "enter attack step"
 	case Attack:
-		return fmt.Sprintf("attack with %v", a.Card.String())
+		return fmt.Sprintf("attack with %s", a.Card)
 	case Block:
-		return fmt.Sprintf("%v blocks %v", a.Card.String(), a.Target.String())
+		return fmt.Sprintf("%s blocks %s", a.Card, a.Target)
 	case UseForMana:
-		return fmt.Sprintf("tap %v for mana", a.Card.String())
+		return fmt.Sprintf("tap %s for mana", a.Card)
 	}
 	panic("control should not reach here")
 }

--- a/game/card.go
+++ b/game/card.go
@@ -1,14 +1,18 @@
 package game
 
 import (
-	"fmt"
 	"log"
-	"strings"
 )
 
+// Card should be treated as immutable.
+// The properties on Card are the properties like "base toughness" that do not change
+// over time for a particular card.
 type Card struct {
-	// Things that are relevant wherever the card is
 	AddsTemporaryEffect bool
+	Bloodthirst         int
+	Flying              bool
+	GroundEvader        bool // only blockable by fliers (like Silhana Ledgewalker)
+	Hexproof            bool
 	HasMorbid           bool
 	HasKicker           bool
 	IsLand              bool
@@ -20,32 +24,9 @@ type Card struct {
 	Modifier            *Modifier
 	Morbid              *Modifier
 	Name                CardName
-	Owner               *Player
+	Powermenace         bool // only blockable by >= power (like Skarrgan Pitskulk)
 
-	// Properties that are relevant for any permanent
-	Auras      []*Card
-	Effects    []*Effect
-	Tapped     bool
-	TurnPlayed int
-
-	// Creature-specific properties
-	Attacking         bool
-	Blocking          *Card
-	Bloodthirst       int
-	DamageOrder       []*Card
-	Damage            int
-	Flying            bool
-	GroundEvader      bool // a fake keyword for Silhana Ledgewalker that faux flies
-	Hexproof          bool
-	PowerCounters     int
-	Powermenace       bool // a fake keyword for Skarrgan Pitskulk, who can only be blocked by >= Power
-	ToughnessCounters int
-
-	// Auras, equipment, instants, and sorceries can have targets
-	Target *Card
-
-	// For creatures these are natural.
-	// For auras and equipment, these indicate the boost the target gets.
+	// The base properties of creatures.
 	BasePower     int
 	BaseToughness int
 	BaseTrample   bool
@@ -158,14 +139,14 @@ func newCardHelper(name CardName) *Card {
 			Morbid - Put three +1/+1 counters on that creature instead if a creature died this turn.
 		*/
 		return &Card{
-			HasMorbid:         true,
-			IsInstant:         true,
-			PowerCounters:     1,
-			ToughnessCounters: 1,
-			ManaCost:          1,
+			HasMorbid: true,
+			IsInstant: true,
+			Modifier: &Modifier{
+				Plus1Plus1Counters: 1,
+			},
+			ManaCost: 1,
 			Morbid: &Modifier{
-				PowerCounters:     2,
-				ToughnessCounters: 2,
+				Plus1Plus1Counters: 2,
 			},
 		}
 	default:
@@ -175,229 +156,6 @@ func newCardHelper(name CardName) *Card {
 }
 
 func (c *Card) String() string {
-	if c.IsLand {
-		return fmt.Sprintf("%v", c.Name)
-	} else if c.IsCreature {
-		return fmt.Sprintf("%v (%v/%v)", c.Name, c.Power(), c.Toughness())
-	}
-	return fmt.Sprintf("%v", c.Name)
-}
-
-func (c *Card) AsciiImage(showBack bool) [CARD_HEIGHT][CARD_WIDTH]string {
-	const cardWidth = CARD_WIDTH
-	const cardHeight = CARD_HEIGHT
-	imageGrid := [cardHeight][cardWidth]string{}
-	for y := 0; y < cardHeight; y++ {
-		for x := 0; x < cardWidth; x++ {
-			if y == 0 || y == cardHeight-1 {
-				imageGrid[y][x] = string('-')
-			} else if x == 0 || x == cardWidth-1 {
-				imageGrid[y][x] = string('|')
-			} else {
-				imageGrid[y][x] = string(' ')
-			}
-		}
-	}
-
-	initialIndex := 2
-
-	if showBack {
-		middleX := cardWidth / 2
-		middleY := cardHeight / 2
-
-		noon := []int{middleX, middleY - 1}
-		two := []int{middleX + 2, middleY}
-		ten := []int{middleX - 2, middleY}
-		seven := []int{middleX - 1, middleY + 1}
-		four := []int{middleX + 1, middleY + 1}
-
-		points := [][]int{noon, two, four, seven, ten}
-		for _, p := range points {
-			imageGrid[p[1]][p[0]] = string('*')
-		}
-	} else {
-		nameRow := 2
-		words := strings.Split(fmt.Sprintf("%v", c.Name), " ")
-		for _, word := range words {
-			wordWidth := Min(3, len(word))
-			if len(words) == 1 {
-				wordWidth = Min(len(word), cardWidth-4)
-			}
-			for x := initialIndex; x < wordWidth+initialIndex; x++ {
-				imageGrid[nameRow][x] = string(word[x-initialIndex])
-			}
-			initialIndex += wordWidth + 1
-			if initialIndex >= cardWidth-wordWidth-1 {
-				break
-			}
-		}
-
-		if c.IsCreature {
-			initialIndex := 2
-			statsRow := 3
-			statsString := fmt.Sprintf("%v/%v", c.Power(), c.Toughness())
-			for x := initialIndex; x < len(statsString)+initialIndex; x++ {
-				imageGrid[statsRow][x] = string(statsString[x-initialIndex])
-			}
-
-		}
-
-		if !c.IsLand {
-			initialIndex := 2
-			ccRow := 1
-			ccString := fmt.Sprintf("%v", c.ManaCost)
-			for x := initialIndex; x < len(ccString)+initialIndex; x++ {
-				imageGrid[ccRow][x] = string(ccString[x-initialIndex])
-			}
-		}
-
-		if c.Tapped {
-			tappedRow := 0
-			initialIndex := 0
-			tappedString := "TAPPED"
-			for x := initialIndex; x < len(tappedString)+initialIndex; x++ {
-				imageGrid[tappedRow][x] = string(tappedString[x-initialIndex])
-			}
-		}
-	}
-
-	return imageGrid
-}
-
-func Min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-func (c *Card) Power() int {
-	answer := c.BasePower + c.PowerCounters
-	for _, aura := range c.Auras {
-		answer += aura.BasePower
-	}
-	for _, effect := range c.Effects {
-		answer += effect.Card.Modifier.Power
-		if effect.Action.WithKicker {
-			answer += effect.Card.Kicker.Power
-		}
-	}
-	return answer
-}
-
-func (c *Card) Toughness() int {
-	answer := c.BaseToughness + c.ToughnessCounters
-	for _, aura := range c.Auras {
-		answer += aura.BaseToughness
-	}
-	for _, effect := range c.Effects {
-		answer += effect.Card.Modifier.Toughness
-		if effect.Action.WithKicker {
-			answer += effect.Card.Kicker.Toughness
-		}
-	}
-	return answer
-}
-
-func (c *Card) Targetable(targetingSpell *Card) bool {
-	answer := true
-	if targetingSpell.Owner != c.Owner && c.Hexproof {
-		return false
-	}
-	for _, effect := range c.Effects {
-		if effect.Card.Modifier.Untargetable == true {
-			return false
-		}
-		if targetingSpell.Owner != c.Owner && effect.Card.Modifier.Hexproof == true {
-			return false
-		}
-	}
-	return answer
-}
-
-func (c *Card) CanAttack(g *Game) bool {
-	if c.Tapped || !c.IsCreature || c.Power() == 0 || c.TurnPlayed == g.Turn {
-		return false
-	}
-	return true
-}
-
-func (c *Card) Trample() bool {
-	if c.BaseTrample {
-		return true
-	}
-	for _, aura := range c.Auras {
-		if aura.BaseTrample {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *Card) RespondToUntapPhase() {
-	if c.Name != NettleSentinel {
-		c.Tapped = false
-	}
-}
-
-func (c *Card) RespondToSpell(spell *Card) {
-	if c.Name == NettleSentinel {
-		c.Tapped = false
-	}
-}
-
-func (c *Card) ManaActions() []*Action {
-	if c.Name == Forest && !c.Tapped {
-		return []*Action{&Action{Type: UseForMana, Card: c}}
-	}
-	return []*Action{}
-}
-
-func (c *Card) UseForMana() {
-	c.Owner.AddMana()
-	c.Tapped = true
-}
-
-// TODO MAKE THIS NOT NAME THE CARDS, JUST USE THE KEYWORDS
-
-func (c *Card) DoEffect(action *Action) {
-	if c.AddsTemporaryEffect {
-		action.Target.Effects = append(action.Target.Effects, &Effect{Action: action, Card: c})
-	}
-	// note that Counters and Morbid Counters are additive
-	action.Target.PowerCounters += c.PowerCounters
-	action.Target.ToughnessCounters += c.ToughnessCounters
-	if c.HasMorbid && (c.Owner.CreatureDied || c.Owner.Opponent().CreatureDied) {
-		action.Target.PowerCounters += c.Morbid.PowerCounters
-		action.Target.ToughnessCounters += c.Morbid.ToughnessCounters
-	}
-}
-
-func (c *Card) HasLegalTarget(g *Game) bool {
-	for _, creature := range g.Creatures() {
-		if creature.Targetable(c) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *Card) CanBlock(attacker *Card) bool {
-	if attacker.GroundEvader && !c.Flying {
-		return false
-	}
-	if attacker.Flying && !c.Flying {
-		return false
-	}
-	if attacker.Powermenace && attacker.Power() > c.Power() {
-		return false
-	}
-	return true
-}
-
-func (c *Card) DoComesIntoPlayEffects() {
-	if c.Bloodthirst > 0 && c.Owner.Opponent().DamageThisTurn > 0 {
-		c.PowerCounters += c.Bloodthirst
-		c.ToughnessCounters += c.Bloodthirst
-	}
+	p := &Permanent{Card: c}
+	return p.String()
 }

--- a/game/game.go
+++ b/game/game.go
@@ -153,8 +153,9 @@ func (g *Game) HandleCombatDamage() {
 	}
 }
 
-func (g *Game) Creatures() []*Card {
-	answer := []*Card{}
+// Creatures() returns the creatures in play.
+func (g *Game) Creatures() []*Permanent {
+	answer := []*Permanent{}
 	for _, player := range g.Players {
 		answer = append(answer, player.Creatures()...)
 	}
@@ -197,7 +198,7 @@ func (g *Game) TakeAction(action *Action) {
 	}
 
 	if action.Type == UseForMana {
-		action.Card.UseForMana()
+		action.With.UseForMana()
 		return
 	}
 
@@ -220,15 +221,15 @@ func (g *Game) TakeAction(action *Action) {
 		if action.Type != Attack {
 			panic("expected an attack or a pass during DeclareAttackers")
 		}
-		action.Card.Attacking = true
-		action.Card.Tapped = true
+		action.With.Attacking = true
+		action.With.Tapped = true
 
 	case DeclareBlockers:
 		if action.Type != Block {
 			panic("expected a block or a pass during DeclareBlockers")
 		}
-		action.Card.Blocking = action.Target
-		action.Target.DamageOrder = append(action.Target.DamageOrder, action.Card)
+		action.With.Blocking = action.Target
+		action.Target.DamageOrder = append(action.Target.DamageOrder, action.With)
 
 	default:
 		panic("unhandled phase")

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -60,7 +60,7 @@ func TestTwoBearsFighting(t *testing.T) {
 	}
 	g.TakeAction(&Action{
 		Type:   Block,
-		Card:   defendingBear,
+		With:   defendingBear,
 		Target: attackingBear,
 	})
 	g.passUntilPhase(Main2)

--- a/game/human.go
+++ b/game/human.go
@@ -27,11 +27,12 @@ func (h *Human) Action(g *Game) *Action {
 }
 
 func promptForAction(game *Game, actions []*Action) *Action {
+	player := game.Priority()
 	for {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Printf("## Turn %v | %s\n", game.Turn, game.Phase)
 		for index, action := range actions {
-			fmt.Printf("%d) %s\n", index+1, action)
+			fmt.Printf("%d) %s\n", index+1, action.ShowTo(player))
 		}
 		fmt.Print("\nEnter a number: ")
 		text, _ := reader.ReadString('\n')
@@ -48,21 +49,23 @@ func promptForAction(game *Game, actions []*Action) *Action {
 }
 
 func promptForTargetAndMana(game *Game, action *Action) *Action {
+	player := game.Priority()
+	c := action.Card
 	actions := []*Action{}
 	for _, target := range game.Creatures() {
 		actions = append(actions, &Action{
 			Type:   Play,
-			Card:   action.Card,
+			Card:   c,
 			Target: target,
 		})
 	}
-	mana := action.Card.Owner.AvailableMana()
-	if action.Card.IsInstant && action.Card.HasKicker && action.Card.Kicker.Cost > 0 && mana >= action.Card.Kicker.Cost && action.Card.HasLegalTarget(action.Card.Owner.game) {
-		for _, target := range action.Card.Owner.game.Creatures() {
-			if target.Targetable(action.Card) {
+	mana := game.Priority().AvailableMana()
+	if c.IsInstant && c.HasKicker && c.Kicker.Cost > 0 && mana >= c.Kicker.Cost {
+		for _, target := range game.Creatures() {
+			if player.IsLegalTarget(c, target) {
 				actions = append(actions, &Action{
 					Type:       Play,
-					Card:       action.Card,
+					Card:       c,
 					WithKicker: true,
 					Target:     target,
 				})

--- a/game/modifier.go
+++ b/game/modifier.go
@@ -13,11 +13,10 @@ package game
 import ()
 
 type Modifier struct {
-	Cost              int // when a Modifier is a kicker, it has a Cost
-	Hexproof          bool
-	Power             int
-	PowerCounters     int
-	Toughness         int
-	ToughnessCounters int
-	Untargetable      bool
+	Cost               int // when a Modifier is a kicker, it has a Cost
+	Hexproof           bool
+	Plus1Plus1Counters int
+	Power              int
+	Toughness          int
+	Untargetable       bool
 }

--- a/game/permanent.go
+++ b/game/permanent.go
@@ -1,0 +1,217 @@
+package game
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Permanent struct {
+	*Card
+
+	// Properties that are relevant for any permanent
+	Auras      []*Permanent
+	Effects    []*Effect
+	Owner      *Player
+	Tapped     bool
+	TurnPlayed int
+
+	// Creature-specific properties
+	Attacking          bool
+	Blocking           *Permanent
+	DamageOrder        []*Permanent
+	Damage             int
+	Plus1Plus1Counters int
+
+	// Auras, equipment, instants, and sorceries can have targets
+	Target *Permanent
+}
+
+func (p *Permanent) String() string {
+	if p.IsLand {
+		return fmt.Sprintf("%s", p.Name)
+	} else if p.IsCreature {
+		return fmt.Sprintf("%s (%d/%d)", p.Name, p.Power(), p.Toughness())
+	}
+	return fmt.Sprintf("%s", p.Name)
+}
+
+func (c *Permanent) AsciiImage(showBack bool) [CARD_HEIGHT][CARD_WIDTH]string {
+	const cardWidth = CARD_WIDTH
+	const cardHeight = CARD_HEIGHT
+	imageGrid := [cardHeight][cardWidth]string{}
+	for y := 0; y < cardHeight; y++ {
+		for x := 0; x < cardWidth; x++ {
+			if y == 0 || y == cardHeight-1 {
+				imageGrid[y][x] = string('-')
+			} else if x == 0 || x == cardWidth-1 {
+				imageGrid[y][x] = string('|')
+			} else {
+				imageGrid[y][x] = string(' ')
+			}
+		}
+	}
+
+	initialIndex := 2
+
+	if showBack {
+		middleX := cardWidth / 2
+		middleY := cardHeight / 2
+
+		noon := []int{middleX, middleY - 1}
+		two := []int{middleX + 2, middleY}
+		ten := []int{middleX - 2, middleY}
+		seven := []int{middleX - 1, middleY + 1}
+		four := []int{middleX + 1, middleY + 1}
+
+		points := [][]int{noon, two, four, seven, ten}
+		for _, p := range points {
+			imageGrid[p[1]][p[0]] = string('*')
+		}
+	} else {
+		nameRow := 2
+		words := strings.Split(fmt.Sprintf("%v", c.Name), " ")
+		for _, word := range words {
+			wordWidth := Min(3, len(word))
+			if len(words) == 1 {
+				wordWidth = Min(len(word), cardWidth-4)
+			}
+			for x := initialIndex; x < wordWidth+initialIndex; x++ {
+				imageGrid[nameRow][x] = string(word[x-initialIndex])
+			}
+			initialIndex += wordWidth + 1
+			if initialIndex >= cardWidth-wordWidth-1 {
+				break
+			}
+		}
+
+		if c.IsCreature {
+			initialIndex := 2
+			statsRow := 3
+			statsString := fmt.Sprintf("%v/%v", c.Power(), c.Toughness())
+			for x := initialIndex; x < len(statsString)+initialIndex; x++ {
+				imageGrid[statsRow][x] = string(statsString[x-initialIndex])
+			}
+
+		}
+
+		if !c.IsLand {
+			initialIndex := 2
+			ccRow := 1
+			ccString := fmt.Sprintf("%v", c.ManaCost)
+			for x := initialIndex; x < len(ccString)+initialIndex; x++ {
+				imageGrid[ccRow][x] = string(ccString[x-initialIndex])
+			}
+		}
+
+		if c.Tapped {
+			tappedRow := 0
+			initialIndex := 0
+			tappedString := "TAPPED"
+			for x := initialIndex; x < len(tappedString)+initialIndex; x++ {
+				imageGrid[tappedRow][x] = string(tappedString[x-initialIndex])
+			}
+		}
+	}
+
+	return imageGrid
+}
+
+func Min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func (p *Permanent) Power() int {
+	answer := p.BasePower + p.Plus1Plus1Counters
+	for _, aura := range p.Auras {
+		answer += aura.BasePower
+	}
+	for _, effect := range p.Effects {
+		answer += effect.Card.Modifier.Power
+		if effect.Action.WithKicker {
+			answer += effect.Card.Kicker.Power
+		}
+	}
+	return answer
+}
+
+func (c *Permanent) Toughness() int {
+	answer := c.BaseToughness + c.Plus1Plus1Counters
+	for _, aura := range c.Auras {
+		answer += aura.BaseToughness
+	}
+	for _, effect := range c.Effects {
+		answer += effect.Card.Modifier.Toughness
+		if effect.Action.WithKicker {
+			answer += effect.Card.Kicker.Toughness
+		}
+	}
+	return answer
+}
+
+func (c *Permanent) CanAttack(g *Game) bool {
+	if c.Tapped || !c.IsCreature || c.Power() == 0 || c.TurnPlayed == g.Turn {
+		return false
+	}
+	return true
+}
+
+func (c *Permanent) Trample() bool {
+	if c.BaseTrample {
+		return true
+	}
+	for _, aura := range c.Auras {
+		if aura.BaseTrample {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Permanent) RespondToUntapPhase() {
+	if c.Name != NettleSentinel {
+		c.Tapped = false
+	}
+}
+
+func (c *Permanent) RespondToSpell() {
+	if c.Name == NettleSentinel {
+		c.Tapped = false
+	}
+}
+
+func (c *Permanent) ManaActions() []*Action {
+	if c.Name == Forest && !c.Tapped {
+		return []*Action{&Action{Type: UseForMana, With: c}}
+	}
+	return []*Action{}
+}
+
+func (c *Permanent) UseForMana() {
+	c.Owner.AddMana()
+	c.Tapped = true
+}
+
+func (c *Permanent) CanBlock(attacker *Permanent) bool {
+	if attacker.GroundEvader && !c.Flying {
+		return false
+	}
+	if attacker.Flying && !c.Flying {
+		return false
+	}
+	if attacker.Powermenace && attacker.Power() > c.Power() {
+		return false
+	}
+	return true
+}
+
+func (c *Permanent) HandleComingIntoPlay() {
+	if c.Owner == nil {
+		panic("permanent has unset owner")
+	}
+	if c.Bloodthirst > 0 && c.Owner.Opponent().DamageThisTurn > 0 {
+		c.Plus1Plus1Counters += c.Bloodthirst
+	}
+}


### PR DESCRIPTION
Some properties don't change over time, like a bear's base power being 2. Some properties do change over time, like whether something is tapped. Now the former go on Card, and the latter go on Permanent.

This should hopefully make for fewer bugs, since the compiler will prevent you from doing things like tapping a card in your hand. It will also make it easier to have a small, serializable state, because the whole Card object is immutable and doesn't need to be hashed into the game state. (This was the original goal that led me here.) Now the Card object can be as screwed up as you want, and we won't have to ensure it hashes consistently.