### PR TITLE
use ids instead of pointers in some places

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ You should see it print out something like:
 
 Enter a number:
 ```
+
+If you are doing development, you should also run:
+
+```
+go get golang.org/x/tools/cmd/stringer
+```
+
+and run `go generate ./...` when you change any enums.

--- a/game/card.go
+++ b/game/card.go
@@ -1,8 +1,6 @@
 package game
 
-import (
-	"log"
-)
+import ()
 
 // Card should be treated as immutable.
 // The properties on Card are the properties like "base toughness" that do not change
@@ -40,8 +38,11 @@ type Card struct {
 //go:generate stringer -type=CardName
 type CardName int
 
+// Keep NoCard first, the rest in alphabetical order.
 const (
-	EldraziSpawnToken CardName = iota
+	NoCard CardName = iota
+
+	EldraziSpawnToken
 	Forest
 	GrizzlyBears
 	HungerOfTheHowlpack
@@ -57,142 +58,128 @@ const (
 const CARD_HEIGHT = 5
 const CARD_WIDTH = 11
 
-func NewCard(name CardName) *Card {
-	card := newCardHelper(name)
-	card.Name = name
-	return card
+var Cards = map[CardName]*Card{
+	EldraziSpawnToken: &Card{
+		BasePower:         0,
+		BaseToughness:     1,
+		CastingCost:       &CastingCost{Colorless: 0},
+		Colorless:         1,
+		IsCreature:        true,
+		SacrificesForMana: true,
+	},
+
+	Forest: &Card{
+		Colorless: 1,
+		IsLand:    true,
+	},
+
+	GrizzlyBears: &Card{
+		BasePower:     2,
+		BaseToughness: 2,
+		CastingCost:   &CastingCost{Colorless: 2},
+		IsCreature:    true,
+	},
+
+	NestInvader: &Card{
+		BasePower:        2,
+		BaseToughness:    2,
+		CastingCost:      &CastingCost{Colorless: 2},
+		EntersPlayEffect: &Effect{Summon: EldraziSpawnToken},
+		IsCreature:       true,
+	},
+
+	NettleSentinel: &Card{
+		BasePower:     2,
+		BaseToughness: 2,
+		CastingCost:   &CastingCost{Colorless: 1},
+		IsCreature:    true,
+	},
+
+	/*
+		Enchanted creature gets +2/+0 and has trample.
+		When Rancor is put into a graveyard from the battlefield,
+		return Rancor to its owner's hand.
+	*/
+	Rancor: &Card{
+		BasePower:         2,
+		BaseToughness:     0,
+		CastingCost:       &CastingCost{Colorless: 1},
+		IsEnchantCreature: true,
+	},
+
+	/*
+		Hexproof (This creature can't be the target of spells or abilities your
+		opponents control.)
+		Silhana Ledgewalker can't be blocked except by creatures with flying.
+	*/
+	SilhanaLedgewalker: &Card{
+		BasePower:     1,
+		BaseToughness: 1,
+		CastingCost:   &CastingCost{Colorless: 2},
+		Hexproof:      true,
+		IsCreature:    true,
+		GroundEvader:  true,
+	},
+
+	SkarrganPitskulk: &Card{
+		BasePower:     1,
+		BaseToughness: 1,
+		Bloodthirst:   1,
+		CastingCost:   &CastingCost{Colorless: 1},
+		IsCreature:    true,
+		Powermenace:   true,
+	},
+
+	VaultSkirge: &Card{
+		BasePower:            1,
+		BaseToughness:        1,
+		CastingCost:          &CastingCost{Colorless: 2},
+		Flying:               true,
+		Hexproof:             true,
+		IsCreature:           true,
+		Lifelink:             true,
+		PhyrexianCastingCost: &CastingCost{Life: 2, Colorless: 1},
+	},
+
+	VinesOfVastwood: &Card{
+		AddsTemporaryEffect: true,
+		CastingCost:         &CastingCost{Colorless: 1},
+		IsInstant:           true,
+		Kicker: &Effect{
+			CastingCost: &CastingCost{Colorless: 2},
+			Power:       4,
+			Toughness:   4,
+		},
+		Effect: &Effect{
+			Untargetable: true,
+		},
+	},
+
+	/*
+		Put a +1/+1 counter on target creature.
+		Morbid - Put three +1/+1 counters on that creature instead if a creature died
+		this turn.
+	*/
+	HungerOfTheHowlpack: &Card{
+		Effect: &Effect{
+			Plus1Plus1Counters: 1,
+		},
+		CastingCost: &CastingCost{Colorless: 1},
+		IsInstant:   true,
+		Morbid: &Effect{
+			Plus1Plus1Counters: 2,
+		},
+	},
 }
 
-func newCardHelper(name CardName) *Card {
-	switch name {
-	case EldraziSpawnToken:
-		return &Card{
-			BasePower:         0,
-			BaseToughness:     1,
-			CastingCost:       &CastingCost{Colorless: 0},
-			Colorless:         1,
-			IsCreature:        true,
-			SacrificesForMana: true,
-		}
-	case Forest:
-		return &Card{
-			Colorless: 1,
-			IsLand:    true,
-		}
-	case GrizzlyBears:
-		return &Card{
-			BasePower:     2,
-			BaseToughness: 2,
-			CastingCost:   &CastingCost{Colorless: 2},
-			IsCreature:    true,
-		}
-	case NestInvader:
-		return &Card{
-			BasePower:        2,
-			BaseToughness:    2,
-			CastingCost:      &CastingCost{Colorless: 2},
-			EntersPlayEffect: &Effect{Summon: newCardHelper(EldraziSpawnToken)},
-			IsCreature:       true,
-		}
-	case NettleSentinel:
-		/*
-			Nettle Sentinel doesn't untap during your untap step.
-			Whenever you cast a green spell, you may untap Nettle Sentinel.
-		*/
-		return &Card{
-			BasePower:     2,
-			BaseToughness: 2,
-			CastingCost:   &CastingCost{Colorless: 1},
-			IsCreature:    true,
-		}
-	case Rancor:
-		/*
-			Enchanted creature gets +2/+0 and has trample.
-			When Rancor is put into a graveyard from the battlefield,
-			return Rancor to its owner's hand.
-		*/
-		return &Card{
-			BasePower:         2,
-			BaseToughness:     0,
-			CastingCost:       &CastingCost{Colorless: 1},
-			IsEnchantCreature: true,
-		}
-	case SilhanaLedgewalker:
-		/*
-			Hexproof (This creature can't be the target of spells or abilities your opponents control.)
-			Silhana Ledgewalker can't be blocked except by creatures with flying.
-		*/
-		return &Card{
-			BasePower:     1,
-			BaseToughness: 1,
-			CastingCost:   &CastingCost{Colorless: 2},
-			Hexproof:      true,
-			IsCreature:    true,
-			GroundEvader:  true,
-		}
-	case SkarrganPitskulk:
-		/*
-			Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters the
-			battlefield with a +1/+1 counter on it.)
-			Creatures with power less than Skarrgan Pit-Skulk's power can't block it.
-		*/
-		return &Card{
-			BasePower:     1,
-			BaseToughness: 1,
-			Bloodthirst:   1,
-			CastingCost:   &CastingCost{Colorless: 1},
-			IsCreature:    true,
-			Powermenace:   true,
-		}
-	case VaultSkirge:
-		/*
-			(Phyrexian Black can be paid with either Black or 2 life.)
-			Flying
-			Lifelink (Damage dealt by this creature also causes you to gain that much life.)
-		*/
-		return &Card{
-			BasePower:            1,
-			BaseToughness:        1,
-			CastingCost:          &CastingCost{Colorless: 2},
-			Flying:               true,
-			Hexproof:             true,
-			IsCreature:           true,
-			Lifelink:             true,
-			PhyrexianCastingCost: &CastingCost{Life: 2, Colorless: 1},
-		}
-	case VinesOfVastwood:
-		return &Card{
-			AddsTemporaryEffect: true,
-			CastingCost:         &CastingCost{Colorless: 1},
-			IsInstant:           true,
-			Kicker: &Effect{
-				CastingCost: &CastingCost{Colorless: 2},
-				Power:       4,
-				Toughness:   4,
-			},
-			Effect: &Effect{
-				Untargetable: true,
-			},
-		}
-	case HungerOfTheHowlpack:
-		/*
-			Put a +1/+1 counter on target creature.
-			Morbid - Put three +1/+1 counters on that creature instead if a creature died this turn.
-		*/
-		return &Card{
-			Effect: &Effect{
-				Plus1Plus1Counters: 1,
-			},
-			CastingCost: &CastingCost{Colorless: 1},
-			IsInstant:   true,
-			Morbid: &Effect{
-				Plus1Plus1Counters: 2,
-			},
-		}
-	default:
-		log.Fatalf("unimplemented card name: %d", name)
+func init() {
+	for name, card := range Cards {
+		card.Name = name
 	}
-	panic("control should not reach here")
+}
+
+func (cn CardName) Card() *Card {
+	return Cards[cn]
 }
 
 func (c *Card) String() string {

--- a/game/card.go
+++ b/game/card.go
@@ -60,6 +60,10 @@ const CARD_HEIGHT = 5
 const CARD_WIDTH = 11
 
 var Cards = map[CardName]*Card{
+
+	/*
+		When Burning-Tree Emissary enters the battlefield, add RG.
+	*/
 	BurningTreeEmissary: &Card{
 		BasePower:        2,
 		BaseToughness:    2,
@@ -67,6 +71,7 @@ var Cards = map[CardName]*Card{
 		EntersPlayEffect: &Effect{Colorless: 2},
 		IsCreature:       true,
 	},
+
 	EldraziSpawnToken: &Card{
 		BasePower:         0,
 		BaseToughness:     1,
@@ -76,11 +81,19 @@ var Cards = map[CardName]*Card{
 		SacrificesForMana: true,
 	},
 
+	/*
+		G
+		http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=443154
+	*/
 	Forest: &Card{
 		Colorless: 1,
 		IsLand:    true,
 	},
 
+	/*
+		No card text.
+		http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=4300
+	*/
 	GrizzlyBears: &Card{
 		BasePower:     2,
 		BaseToughness: 2,
@@ -88,6 +101,11 @@ var Cards = map[CardName]*Card{
 		IsCreature:    true,
 	},
 
+	/*
+		When Nest Invader enters the battlefield, create a 0/1 colorless
+		Eldrazi Spawn creature token. It has "Sacrifice this creature:
+		Add (1)."
+	*/
 	NestInvader: &Card{
 		BasePower:        2,
 		BaseToughness:    2,
@@ -96,6 +114,10 @@ var Cards = map[CardName]*Card{
 		IsCreature:       true,
 	},
 
+	/*
+		Nettle Sentinel doesn't untap during your untap step.
+		Whenever you cast a green spell, you may untap Nettle Sentinel.
+	*/
 	NettleSentinel: &Card{
 		BasePower:     2,
 		BaseToughness: 2,
@@ -129,6 +151,11 @@ var Cards = map[CardName]*Card{
 		GroundEvader:  true,
 	},
 
+	/*
+		Bloodthirst 1 (If an opponent was dealt damage this turn, this creature enters
+		the battlefield with a +1/+1 counter on it.)
+		Creatures with power less than Skarrgan Pit-Skulk's power can't block it.
+	*/
 	SkarrganPitskulk: &Card{
 		BasePower:     1,
 		BaseToughness: 1,
@@ -138,6 +165,11 @@ var Cards = map[CardName]*Card{
 		Powermenace:   true,
 	},
 
+	/*
+		(Phyrexian Black can be paid with either Black or 2 life.)
+		Flying
+		Lifelink (Damage dealt by this creature also causes you to gain that much life.)
+	*/
 	VaultSkirge: &Card{
 		BasePower:            1,
 		BaseToughness:        1,
@@ -149,6 +181,12 @@ var Cards = map[CardName]*Card{
 		PhyrexianCastingCost: &CastingCost{Life: 2, Colorless: 1},
 	},
 
+	/*
+		Kicker Green (You may pay an additional Green as you cast this spell.)
+		Target creature can't be the target of spells or abilities your opponents
+		control this turn. If this spell was kicked, that creature gets +4/+4 until
+		end of turn.
+	*/
 	VinesOfVastwood: &Card{
 		AddsTemporaryEffect: true,
 		CastingCost:         &CastingCost{Colorless: 1},

--- a/game/cardname_string.go
+++ b/game/cardname_string.go
@@ -4,9 +4,9 @@ package game
 
 import "strconv"
 
-const _CardName_name = "EldraziSpawnTokenForestGrizzlyBearsHungerOfTheHowlpackNestInvaderNettleSentinelRancorSilhanaLedgewalkerSkarrganPitskulkVaultSkirgeVinesOfVastwood"
+const _CardName_name = "NoCardEldraziSpawnTokenForestGrizzlyBearsHungerOfTheHowlpackNestInvaderNettleSentinelRancorSilhanaLedgewalkerSkarrganPitskulkVaultSkirgeVinesOfVastwood"
 
-var _CardName_index = [...]uint8{0, 17, 23, 35, 54, 65, 79, 85, 103, 119, 130, 145}
+var _CardName_index = [...]uint8{0, 6, 23, 29, 41, 60, 71, 85, 91, 109, 125, 136, 151}
 
 func (i CardName) String() string {
 	if i < 0 || i >= CardName(len(_CardName_index)-1) {

--- a/game/deck.go
+++ b/game/deck.go
@@ -5,16 +5,17 @@ import (
 )
 
 type Deck struct {
-	Cards        []*Card
+	Cards        []CardName
 	FailedToDraw bool
 }
 
 func NewEmptyDeck() *Deck {
 	return &Deck{
-		Cards: []*Card{},
+		Cards: []CardName{},
 	}
 }
 
+// Constructs a new deck from the count of each card.
 func NewDeck(decklist map[CardName]int) *Deck {
 	deck := NewEmptyDeck()
 	for name, count := range decklist {
@@ -37,10 +38,10 @@ func Stompy() *Deck {
 	})
 }
 
-func (d *Deck) Draw() *Card {
+func (d *Deck) Draw() CardName {
 	if len(d.Cards) == 0 {
 		d.FailedToDraw = true
-		return nil
+		return NoCard
 	}
 	answer := d.Cards[0]
 	d.Cards = d.Cards[1:]
@@ -58,6 +59,6 @@ func (d *Deck) Shuffle() {
 // Adds cards to the deck, on bottom
 func (d *Deck) Add(n int, name CardName) {
 	for i := 0; i < n; i++ {
-		d.Cards = append(d.Cards, NewCard(name))
+		d.Cards = append(d.Cards, name)
 	}
 }

--- a/game/effect.go
+++ b/game/effect.go
@@ -30,7 +30,7 @@ type Effect struct {
 	Kicker *Effect
 
 	// sometimes an effect summons a creature
-	Summon *Card
+	Summon CardName
 
 	// Source is the source of activated abilities, nil for other effects.
 	Source *Permanent

--- a/game/effect.go
+++ b/game/effect.go
@@ -16,28 +16,25 @@ package game
 import ()
 
 type Effect struct {
-
-	// when an Effect is a kicker, it has a Cost
+	// when an Effect is a kicker, it has a CastingCost
 	CastingCost *CastingCost
 
-	// these properties modify a Card the Effect targets
+	// these properties modify a Permanent the Effect targets
 	Hexproof           bool
 	Plus1Plus1Counters int
 	Power              int
 	Toughness          int
 	Untargetable       bool
 
-	/*
-		only gets sets when the action for the Effect is withKicker
-		this child Effect adds on top of the normal Effect
-	*/
+	// Kicker is a child Effect added on top of the normal Effect.
 	Kicker *Effect
 
 	// sometimes an effect summons a creature
 	Summon *Card
 
-	// these properties get copied from the Action object from which the Effect is created
+	// Source is the source of activated abilities, nil for other effects.
 	Source *Permanent
+
 	Target *Permanent
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -45,6 +45,7 @@ type Game struct {
 	Permanents map[PermanentId]*Permanent
 }
 
+//go:generate stringer -type=CardName
 type Phase int
 
 // Phase encompasses both "phases" and "steps" as per:
@@ -250,7 +251,8 @@ func (g *Game) IsOver() bool {
 }
 
 // All permanents added to the game should be created via newPermanent.
-// This assigns a unique id to the permanent.
+// This assigns a unique id to the permanent and activates any coming-into-play
+// effects.
 func (g *Game) newPermanent(card *Card, owner *Player) *Permanent {
 	perm := &Permanent{
 		Card:       card,
@@ -260,6 +262,8 @@ func (g *Game) newPermanent(card *Card, owner *Player) *Permanent {
 	}
 	g.Permanents[g.NextPermanentId] = perm
 	g.NextPermanentId++
+	owner.Board = append(owner.Board, perm)
+	perm.HandleComingIntoPlay()
 	return perm
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -37,6 +37,12 @@ type Game struct {
 
 	// The id of the player with priority
 	PriorityId PlayerId
+
+	// The PermanentId that will be assigned to the next permanent that enters play
+	NextPermanentId PermanentId
+
+	// Permanents contains all permanents in play.
+	Permanents map[PermanentId]*Permanent
 }
 
 type Phase int
@@ -59,10 +65,12 @@ func NewGame(deckToPlay *Deck, deckToDraw *Deck) *Game {
 		NewPlayer(deckToDraw, OnTheDraw),
 	}
 	g := &Game{
-		Players:    players,
-		Phase:      Main1,
-		Turn:       0,
-		PriorityId: OnThePlay,
+		Players:         players,
+		Phase:           Main1,
+		Turn:            0,
+		PriorityId:      OnThePlay,
+		NextPermanentId: PermanentId(1),
+		Permanents:      make(map[PermanentId]*Permanent),
 	}
 
 	players[0].game = g
@@ -239,6 +247,32 @@ func (g *Game) TakeAction(action *Action) {
 
 func (g *Game) IsOver() bool {
 	return g.Attacker().Lost() || g.Defender().Lost()
+}
+
+// All permanents added to the game should be created via newPermanent.
+// This assigns a unique id to the permanent.
+func (g *Game) newPermanent(card *Card, owner *Player) *Permanent {
+	perm := &Permanent{
+		Card:       card,
+		Owner:      owner,
+		TurnPlayed: g.Turn,
+		Id:         g.NextPermanentId,
+	}
+	g.Permanents[g.NextPermanentId] = perm
+	g.NextPermanentId++
+	return perm
+}
+
+// removePermanent does nothing if the permanent has already been removed.
+func (g *Game) removePermanent(id PermanentId) {
+	delete(g.Permanents, id)
+}
+
+func (g *Game) Permanent(id PermanentId) *Permanent {
+	if id == PermanentId(0) {
+		panic("0 is not a valid PermanentId")
+	}
+	return g.Permanents[id]
 }
 
 func (g *Game) Print() {

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+	"log"
 	"testing"
 )
 
@@ -32,10 +33,16 @@ func TestDecking(t *testing.T) {
 }
 
 func TestTwoBearsFighting(t *testing.T) {
-	g := NewGame(deckWithTopAndForests(GrizzlyBears), deckWithTopAndForests(GrizzlyBears))
+	g := NewGame(
+		deckWithTopAndForests(GrizzlyBears),
+		deckWithTopAndForests(GrizzlyBears))
+
+	log.Printf("starting first turn")
 
 	g.playLand()
 	g.passTurn()
+
+	log.Printf("finished first turn")
 
 	g.playLand()
 	g.passTurn()

--- a/game/permanent.go
+++ b/game/permanent.go
@@ -5,8 +5,15 @@ import (
 	"strings"
 )
 
+// A PermanentId is provided for each permanent when it enters the battlefield.
+// Each id is unique for a particular game and is never reused for subsequent
+// permanents.
+// 0 is not a valid PermanentId.
+type PermanentId int
+
 type Permanent struct {
 	*Card
+	Id PermanentId
 
 	// Properties that are relevant for any permanent
 	Auras      []*Permanent

--- a/game/permanent.go
+++ b/game/permanent.go
@@ -8,7 +8,8 @@ import (
 // A PermanentId is provided for each permanent when it enters the battlefield.
 // Each id is unique for a particular game and is never reused for subsequent
 // permanents.
-// 0 is not a valid PermanentId.
+// The first allocated id is 1. This way, 0 is not a valid PermanentId, so if you
+// see anything with an id of 0 it means we are using something uninitialized.
 type PermanentId int
 
 type Permanent struct {

--- a/game/player.go
+++ b/game/player.go
@@ -324,11 +324,7 @@ func (p *Player) Play(action *Action) {
 	}
 
 	// Non-instant cards turn into a permanent
-	perm := &Permanent{
-		Card:  card,
-		Owner: p,
-	}
-	perm.TurnPlayed = p.game.Turn
+	perm := p.game.newPermanent(card, p)
 
 	if card.IsLand {
 		p.LandPlayedThisTurn++

--- a/game/player.go
+++ b/game/player.go
@@ -11,7 +11,7 @@ type Player struct {
 	CreatureDied       bool
 	DamageThisTurn     int
 	Deck               *Deck
-	Hand               []*Card
+	Hand               []CardName
 	Id                 PlayerId
 	LandPlayedThisTurn int
 	Life               int
@@ -24,7 +24,7 @@ type Player struct {
 func NewPlayer(deck *Deck, id PlayerId) *Player {
 	p := &Player{
 		Life:  20,
-		Hand:  []*Card{},
+		Hand:  []CardName{},
 		Id:    id,
 		Board: []*Permanent{},
 		Deck:  deck,
@@ -40,8 +40,8 @@ func (p *Player) Draw() {
 	p.AddToHand(card)
 }
 
-func (p *Player) AddToHand(c *Card) {
-	if c == nil {
+func (p *Player) AddToHand(c CardName) {
+	if c == NoCard {
 		return
 	}
 	p.Hand = append(p.Hand, c)
@@ -141,7 +141,7 @@ func (p *Player) RemoveFromBoard(perm *Permanent) {
 	p.Board = newBoard
 
 	if perm.Name == Rancor {
-		p.AddToHand(NewCard(Rancor))
+		p.AddToHand(Rancor)
 	} else {
 		// TODO: make sure it is actually a creature that died
 		p.CreatureDied = true
@@ -159,12 +159,13 @@ func (p *Player) PlayActions(allowSorcerySpeed bool, forHuman bool) []*Action {
 	answer := []*Action{&Action{Type: Pass}}
 
 	mana := p.AvailableMana()
-	for _, card := range p.Hand {
+	for _, name := range p.Hand {
 		// Don't re-check playing duplicate cards
-		if cardNames[card.Name] {
+		if cardNames[name] {
 			continue
 		}
-		cardNames[card.Name] = true
+		cardNames[name] = true
+		card := name.Card()
 
 		if allowSorcerySpeed {
 			if card.IsLand && p.LandPlayedThisTurn == 0 {
@@ -295,11 +296,18 @@ func (p *Player) BlockActions() []*Action {
 
 func (p *Player) Play(action *Action) {
 	card := action.Card
-	newHand := []*Card{}
+	newHand := []CardName{}
+	found := false
 	for _, c := range p.Hand {
-		if c != card {
-			newHand = append(newHand, c)
+		if !found && c == card.Name {
+			found = true
+			continue
 		}
+		newHand = append(newHand, c)
+	}
+	if !found {
+		log.Printf("could not play card %+v from hand %+v", card, p.Hand)
+		panic("XXX")
 	}
 	p.Hand = newHand
 
@@ -329,9 +337,6 @@ func (p *Player) Play(action *Action) {
 	if card.IsLand {
 		p.LandPlayedThisTurn++
 	}
-
-	p.Board = append(p.Board, perm)
-	perm.HandleComingIntoPlay()
 
 	if card.IsEnchantCreature {
 		action.Target.Auras = append(action.Target.Auras, perm)
@@ -398,10 +403,10 @@ func (p *Player) AvatarString(position int, gameWidth int) string {
 	return playerString
 }
 
-func PrintRowOfCards(cards []*Card, gameWidth int) {
+func PrintRowOfCards(cards []CardName, gameWidth int) {
 	perms := []*Permanent{}
-	for _, card := range cards {
-		perms = append(perms, &Permanent{Card: card})
+	for _, name := range cards {
+		perms = append(perms, &Permanent{Card: name.Card()})
 	}
 	PrintRowOfPermanents(perms, gameWidth)
 }
@@ -467,13 +472,7 @@ func (p *Player) HasLegalTarget(c *Card) bool {
 }
 
 func (p *Player) ResolveEffect(e *Effect) {
-	if e.Summon != nil {
-		perm := &Permanent{
-			Card:  e.Summon,
-			Owner: p,
-		}
-		perm.TurnPlayed = p.game.Turn
-		p.Board = append(p.Board, perm)
-		perm.HandleComingIntoPlay()
+	if e.Summon != NoCard {
+		p.game.newPermanent(e.Summon.Card(), p)
 	}
 }


### PR DESCRIPTION
Permanents now all get a PermanentId when they come into play. Also, cards in your hand are just the CardName, not the whole card.

It is not totally there yet but the goal is to create a game object with no pointer cycles (except the game pointers which will explicitly not get encoded) so that it can be simply and quickly encoded and decoded.